### PR TITLE
Test allocation count

### DIFF
--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -139,8 +139,9 @@ func SubConnection(n string, c ConnType) {
 func RegisterAllocationMetric(log logging.LeveledLogger, GetAllocationCount func() float64) {
 	AllocActiveGauge = prometheus.NewGaugeFunc(
 		prometheus.GaugeOpts{
-			Name: "stunner_allocations_active",
-			Help: "Number of active allocations.",
+			Namespace: stunnerNamespace,
+			Name:      "allocations_active",
+			Help:      "Number of active allocations.",
 		},
 		GetAllocationCount,
 	)

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -1,6 +1,7 @@
 package telemetry
 
 import (
+	"github.com/pion/logging"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -11,6 +12,7 @@ const (
 var (
 	ConnLabels           = []string{"name"}
 	CounterLabels        = []string{"name", "direction"}
+	AllocActiveGauge     prometheus.GaugeFunc
 	ListenerPacketsTotal *prometheus.CounterVec
 	ListenerBytesTotal   *prometheus.CounterVec
 	ListenerConnsTotal   *prometheus.CounterVec
@@ -134,30 +136,30 @@ func SubConnection(n string, c ConnType) {
 	}
 }
 
-// func RegisterMetrics(log logging.LeveledLogger, GetAllocationCount func() float64) {
-// 	AllocActiveGauge = prometheus.NewGaugeFunc(
-// 		prometheus.GaugeOpts{
-// 			Name: "stunner_allocations_active",
-// 			Help: "Number of active allocations.",
-// 		},
-// 		GetAllocationCount,
-// 	)
-// 	if err := prometheus.Register(AllocActiveGauge); err == nil {
-// 		log.Debug("GaugeFunc 'stunner_allocations_active' registered.")
-// 	} else {
-// 		log.Warn("GaugeFunc 'stunner_allocations_active' cannot be registered.")
-// 	}
-// }
+func RegisterAllocationMetric(log logging.LeveledLogger, GetAllocationCount func() float64) {
+	AllocActiveGauge = prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{
+			Name: "stunner_allocations_active",
+			Help: "Number of active allocations.",
+		},
+		GetAllocationCount,
+	)
+	if err := prometheus.Register(AllocActiveGauge); err == nil {
+		log.Debug("GaugeFunc 'stunner_allocations_active' registered.")
+	} else {
+		log.Warn("GaugeFunc 'stunner_allocations_active' cannot be registered.")
+	}
+}
 
-// func UnregisterMetrics(log logging.LeveledLogger) {
-// 	if AllocActiveGauge != nil {
-// 		if success := prometheus.Unregister(AllocActiveGauge); success {
-// 			log.Debug("GaugeFunc 'stunner_allocations_active' unregistered.")
-// 			return
-// 		}
-// 	}
-// 	log.Warn("GaugeFunc 'stunner_allocations_active' cannot be unregistered.")
-// }
+func UnregisterAllocationMetric(log logging.LeveledLogger) {
+	if AllocActiveGauge != nil {
+		if success := prometheus.Unregister(AllocActiveGauge); success {
+			log.Debug("GaugeFunc 'stunner_allocations_active' unregistered.")
+			return
+		}
+	}
+	log.Warn("GaugeFunc 'stunner_allocations_active' cannot be unregistered.")
+}
 
 // func GetListenerPacketsTotal(ch chan prometheus.Metric) {
 // 	go func() {

--- a/stunner.go
+++ b/stunner.go
@@ -104,7 +104,7 @@ func NewStunner(options Options) *Stunner {
 	if !s.dryRun {
 		s.resolver.Start()
 		telemetry.Init()
-		// telemetry.RegisterMetrics(s.log, func() float64 { return s.GetActiveConnections() })
+		telemetry.RegisterAllocationMetric(s.log, s.GetActiveConnections)
 	}
 
 	// TODO: remove this when STUNner gains self-managed dataplanes
@@ -275,7 +275,7 @@ func (s *Stunner) Close() {
 		}
 	}
 
-	// telemetry.UnregisterMetrics(s.log)
+	telemetry.UnregisterAllocationMetric(s.log)
 	if !s.dryRun {
 		telemetry.Close()
 	}
@@ -284,4 +284,7 @@ func (s *Stunner) Close() {
 }
 
 // GetActiveConnections returns the number of active downstream (listener-side) TURN allocations.
-func (s *Stunner) GetActiveConnections() float64 { return 0.0 }
+func (s *Stunner) GetActiveConnections() float64 {
+	count := s.AllocationCount()
+	return float64(count)
+}


### PR DESCRIPTION
Hello!

I'm currently monitoring a TURN server using Stunner (Headless deployment model) and have come across an issue with the stunner_listener_connections metric. This metric is described in the documentation as representing the "Number of active downstream connections at a listener." However, in my setup, it consistently reports a value of 16, which coincidentally matches the --udp-thread-num setting, regardless of the service's actual usage.

I found an [answer in the discord](https://discord.com/channels/945255818494902282/1173611480080449647/1173738162502258768) that explains that it is expected behavior when using UDP for Stunner as I do. And then there is an interesting message:

> That being said, we should really implement a TURN allocation counter that would wrap this API: [stunner package - github.com/l7mp/stunner - Go Packages](https://pkg.go.dev/github.com/l7mp/stunner#Stunner.GetActiveConnections.)  This is a TODO list item currently I'm afraid. If you feel you really need this, please submit an issue at GitHub, we tend to prioritize wishlist items

I looked at the code and found that it was almost already implemented. I made the changes to make it work and validated that it works in my test environment. As suggested in the discord message, i want to submit this to voice the need for the metric!